### PR TITLE
Fix missing User object for UserEmail creation

### DIFF
--- a/sentry_auth_ldap/backend.py
+++ b/sentry_auth_ldap/backend.py
@@ -55,6 +55,10 @@ class SentryLdapBackend(LDAPBackend):
 
             if email:
                 user.email = email
+            
+            user.save()
+
+            if email:
                 UserEmail.objects.get_or_create(user=user, email=email)
 
         # Check to see if we need to add the user to an organization


### PR DESCRIPTION
(I don't know, if this is the cleanest fix, but this is what is working for me, at least.)

Without the `user.save()` call prior to `UserEMail.objects.get_or_create`, I got the following exception, when logging in with a new ldap account:
`sentry.models.useremail.UserEmail.DoesNotExist: UserEmail matching query does not exist.`

This results from the UserEmail table referencing the new User object, which has not been persisted to database yet.