### PR TITLE
Avoid explicitly depending on Sentry by default

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,12 +13,15 @@ with open("README.md", "r") as readme:
 
 install_requires = [
     'django-auth-ldap==4.1.0',
-    'sentry>=21.9.0',
 ]
+
+extras_require = {
+    'sentry': 'sentry>=21.9.0',
+}
 
 setup(
     name='sentry-auth-ldap',
-    version='21.9.11',
+    version='21.9.12',
     author='Chad Killingsworth <chad.killingsworth@banno.com>, Barron Hagerman <barron.hagerman@banno.com>, PM Extra <pm@jubeat.net>',
     author_email='pm@jubeat.net',
     url='https://github.com/PMExtra/sentry-auth-ldap',
@@ -29,6 +32,7 @@ setup(
     license='Apache-2.0',
     zip_safe=False,
     install_requires=install_requires,
+    extras_require=extras_require,
     include_package_data=True,
     download_url='https://github.com/PMExtra/sentry-auth-ldap',
     classifiers=[


### PR DESCRIPTION
As this module is more or less a plugin to Sentry proper, it seems extremely unlikely that this dependency is actually used - most users would probably already have Sentry and installing sentry-auth-ldap alongside.

Keeping it here, however, makes using things like Pipenv/Poetry/etc a bit inconvenient as the newest (>= 21.9.0) version of Sentry (plus _a lot_ of its subdependencies) will always end up in the lockfile - and Sentry itself may have come from another source, external to the package manager, such as the `getsentry/sentry` image from Docker Hub[^1].

After this commit, it will still be possible to pull Sentry into the dependency tree after e.g.:

```diff
-sentry-auth-ldap==21.9.11
+sentry-auth-ldap[sentry]==21.9.11
```

[^1]: https://hub.docker.com/r/getsentry/sentry