### PR TITLE
Update OrganizationMember update_or_create field due to Sentry updates

### DIFF
--- a/sentry_auth_ldap/backend.py
+++ b/sentry_auth_ldap/backend.py
@@ -84,7 +84,7 @@ class SentryLdapBackend(LDAPBackend):
         # Add the user to the organization with global access
         OrganizationMember.objects.update_or_create(
             organization=organizations[0],
-            user=user,
+            user_id=user.id,
             defaults={
                 'role': member_role,
                 'has_global_access': has_global_access,

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open("README.md", "r") as readme:
 
 install_requires = [
     'django-auth-ldap==4.1.0',
-    'sentry>=21.9.0',
+    'sentry>=23.6.1',
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     version='21.9.11',
     author='Chad Killingsworth <chad.killingsworth@banno.com>, Barron Hagerman <barron.hagerman@banno.com>, PM Extra <pm@jubeat.net>',
     author_email='pm@jubeat.net',
-    url='https://github.com/bryanjuho/sentry-auth-ldap',
+    url='https://github.com/PMExtra/sentry-auth-ldap',
     description='A Sentry extension to add an LDAP server as an authentication source.',
     long_description=long_description,
     long_description_content_type='text/markdown',
@@ -30,7 +30,7 @@ setup(
     zip_safe=False,
     install_requires=install_requires,
     include_package_data=True,
-    download_url='https://github.com/bryanjuho/sentry-auth-ldap',
+    download_url='https://github.com/PMExtra/sentry-auth-ldap',
     classifiers=[
         'Framework :: Django',
         'Intended Audience :: Developers',
@@ -40,8 +40,8 @@ setup(
         'Topic :: Software Development'
     ],
     project_urls={
-        'Bug Tracker': 'https://github.com/bryanjuho/sentry-auth-ldap/issues',
-        'CI': 'https://github.com/bryanjuho/sentry-auth-ldap/actions',
-        'Source Code': 'https://github.com/bryanjuho/sentry-auth-ldap',
+        'Bug Tracker': 'https://github.com/PMExtra/sentry-auth-ldap/issues',
+        'CI': 'https://github.com/PMExtra/sentry-auth-ldap/actions',
+        'Source Code': 'https://github.com/PMExtra/sentry-auth-ldap',
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     version='21.9.11',
     author='Chad Killingsworth <chad.killingsworth@banno.com>, Barron Hagerman <barron.hagerman@banno.com>, PM Extra <pm@jubeat.net>',
     author_email='pm@jubeat.net',
-    url='https://github.com/PMExtra/sentry-auth-ldap',
+    url='https://github.com/bryanjuho/sentry-auth-ldap',
     description='A Sentry extension to add an LDAP server as an authentication source.',
     long_description=long_description,
     long_description_content_type='text/markdown',
@@ -30,7 +30,7 @@ setup(
     zip_safe=False,
     install_requires=install_requires,
     include_package_data=True,
-    download_url='https://github.com/PMExtra/sentry-auth-ldap',
+    download_url='https://github.com/bryanjuho/sentry-auth-ldap',
     classifiers=[
         'Framework :: Django',
         'Intended Audience :: Developers',
@@ -40,8 +40,8 @@ setup(
         'Topic :: Software Development'
     ],
     project_urls={
-        'Bug Tracker': 'https://github.com/PMExtra/sentry-auth-ldap/issues',
-        'CI': 'https://github.com/PMExtra/sentry-auth-ldap/actions',
-        'Source Code': 'https://github.com/PMExtra/sentry-auth-ldap',
+        'Bug Tracker': 'https://github.com/bryanjuho/sentry-auth-ldap/issues',
+        'CI': 'https://github.com/bryanjuho/sentry-auth-ldap/actions',
+        'Source Code': 'https://github.com/bryanjuho/sentry-auth-ldap',
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open("README.md", "r") as readme:
 
 install_requires = [
     'django-auth-ldap==4.1.0',
-    'sentry>=23.6.1',
+    'sentry>=21.9.0',
 ]
 
 setup(


### PR DESCRIPTION
Sentry has changed their [OrganizationModel's user field to user_id](https://github.com/getsentry/sentry/blob/affc86677fef90bc5e1895ffd07337c41cb0b72c/src/sentry/models/organizationmember.py#L192).  Commit: [Link](https://github.com/getsentry/sentry/commit/cd5d40f7cefe7061ba50eec854888b77751f5e36)

This causes FieldError because user used to be an User object.