### PR TITLE
Allow modifying OrganizationMember after initial creation

### DIFF
--- a/sentry_auth_ldap/backend.py
+++ b/sentry_auth_ldap/backend.py
@@ -74,9 +74,10 @@ class SentryLdapBackend(LDAPBackend):
         for mail in mail_attr or [email]:
             UserEmail.objects.update_or_create(defaults=defaults, user=user, email=mail)
 
+        organization = _find_default_organization()
         if organization:
+            sentry_role_from_ldap_group = _get_effective_sentry_role(ldap_user)
             try:
-                sentry_role_from_ldap_group = _get_effective_sentry_role(ldap_user)
                 organization_member = OrganizationMember.objects.get(organization=organization, user_id=user.id)
                 if sentry_role_from_ldap_group:
                     # The role mapped from LDAP will always overrides any manual changes the user might have made

--- a/sentry_auth_ldap/backend.py
+++ b/sentry_auth_ldap/backend.py
@@ -74,16 +74,16 @@ class SentryLdapBackend(LDAPBackend):
         for mail in mail_attr or [email]:
             UserEmail.objects.update_or_create(defaults=defaults, user=user, email=mail)
 
-        organization = _find_default_organization()
         if organization:
-            sentry_role_from_ldap_group = _get_effective_sentry_role(ldap_user)
             try:
+                sentry_role_from_ldap_group = _get_effective_sentry_role(ldap_user)
                 organization_member = OrganizationMember.objects.get(organization=organization, user_id=user.id)
-                # This setting always overrides any manual changes a user might have made
                 if sentry_role_from_ldap_group:
+                    # The role mapped from LDAP will always overrides any manual changes the user might have made
                     organization_member.role = sentry_role_from_ldap_group
                     organization_member.save()
             except OrganizationMember.DoesNotExist:
+                # Assign the user to the organization if not exists
                 OrganizationMember.objects.create(
                     organization=organization,
                     user_id=user.id,
@@ -91,9 +91,9 @@ class SentryLdapBackend(LDAPBackend):
                     has_global_access=getattr(settings, 'AUTH_LDAP_SENTRY_ORGANIZATION_GLOBAL_ACCESS', False),
                     flags=getattr(OrganizationMember.flags, 'sso:linked'),
                 )
-         else
 
-        if not getattr(settings, 'AUTH_LDAP_SENTRY_SUBSCRIBE_BY_DEFAULT', True):
+        # Set subscribe_by_default for new user
+        if built and not getattr(settings, 'AUTH_LDAP_SENTRY_SUBSCRIBE_BY_DEFAULT', True):
             UserOption.objects.set_value(
                 user=user,
                 project=None,


### PR DESCRIPTION
Resolves https://github.com/PMExtra/sentry-auth-ldap/issues/12

Currently untested, I can do the same as in https://github.com/PMExtra/sentry-auth-ldap/pull/8#issuecomment-1609189361 when I have a maintenance window.