### PR TITLE
fix: change import UserEmail for Sentry 24.11.0

### DIFF
--- a/sentry_auth_ldap/backend.py
+++ b/sentry_auth_ldap/backend.py
@@ -1,12 +1,12 @@
 from django_auth_ldap.backend import LDAPBackend
 from django.conf import settings
+
 from sentry.models import (
     Organization,
     OrganizationMember,
-    UserEmail,
     UserOption,
 )
-
+from sentry.users.models import UserEmail
 
 def _get_effective_sentry_role(ldap_user):
     role_priority_order = [

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ install_requires = [
 
 setup(
     name='sentry-auth-ldap',
-    version='23.6.1',
+    version='24.11.0',
     author='Chad Killingsworth <chad.killingsworth@banno.com>, Barron Hagerman <barron.hagerman@banno.com>, PM Extra <pm@jubeat.net>',
     author_email='pm@jubeat.net',
     url='https://github.com/PMExtra/sentry-auth-ldap',


### PR DESCRIPTION
Due to [PR #76134](https://github.com/getsentry/sentry/pull/76134) in Sentry repository, the UserEmail model has been moved to `users` module and import UserEmail now is broken.

I changed import for UserEmail model and bumped package version to 24.11.0. Tested only for Sentry 24.11.0.