### PR TITLE
Map group to team

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ AUTH_LDAP_SENTRY_GROUP_ROLE_MAPPING = {
     'admin': ['devleads'],
     'member': ['developers', 'seniordevelopers']
 }
-AUTH_LDAP_SENTRY_TEAM_MAPPING = {
+AUTH_LDAP_SENTRY_GROUP_TEAM_MAPPING = {
     'app': ['developers', 'devleads'],
     'infrastructure': ['sysadmins']
 }

--- a/README.md
+++ b/README.md
@@ -146,6 +146,10 @@ AUTH_LDAP_SENTRY_GROUP_ROLE_MAPPING = {
     'admin': ['devleads'],
     'member': ['developers', 'seniordevelopers']
 }
+AUTH_LDAP_SENTRY_TEAM_MAPPING = {
+    'app': ['developers', 'devleads'],
+    'infrastructure': ['sysadmins']
+}
 AUTH_LDAP_SENTRY_ORGANIZATION_GLOBAL_ACCESS = True
 
 AUTHENTICATION_BACKENDS = AUTHENTICATION_BACKENDS + (

--- a/sentry_auth_ldap/backend.py
+++ b/sentry_auth_ldap/backend.py
@@ -49,7 +49,7 @@ def _get_effective_sentry_role(ldap_user):
 
 
 def _get_effective_sentry_teams(ldap_user):
-    team_mapping = getattr(settings, 'AUTH_LDAP_SENTRY_TEAM_MAPPING', None)
+    team_mapping = getattr(settings, 'AUTH_LDAP_SENTRY_GROUP_TEAM_MAPPING', None)
     if not team_mapping:
         return []
 

--- a/sentry_auth_ldap/backend.py
+++ b/sentry_auth_ldap/backend.py
@@ -14,7 +14,7 @@ def compare_versions(current: str, required: str) -> bool:
     """
     return version.parse(current) >= version.parse(required)
 
-from sentry.models import Organization, OrganizationMember, UserOption
+from sentry.models import Organization, OrganizationMember, OrganizationMemberTeam, Team, UserOption
 
 # Import different models for backwards compatibility
 if compare_versions(sentry_version, "24.10.0"):
@@ -46,6 +46,18 @@ def _get_effective_sentry_role(ldap_user):
 
     highest_role = [role for role in role_priority_order if role in applicable_roles][-1]
     return highest_role
+
+
+def _get_effective_sentry_teams(ldap_user):
+    team_mapping = getattr(settings, 'AUTH_LDAP_SENTRY_TEAM_MAPPING', None)
+    if not team_mapping:
+        return []
+
+    group_names = ldap_user.group_names
+    if not group_names:
+        return []
+
+    return [team for team, groups in team_mapping.items() if group_names.intersection(groups)]
 
 
 def _find_default_organization():
@@ -101,13 +113,20 @@ class SentryLdapBackend(LDAPBackend):
                     organization_member.save()
             except OrganizationMember.DoesNotExist:
                 # Assign the user to the organization if not exists
-                OrganizationMember.objects.create(
+                organization_member = OrganizationMember.objects.create(
                     organization=organization,
                     user_id=user.id,
                     role=sentry_role_from_ldap_group or getattr(settings, 'AUTH_LDAP_SENTRY_ORGANIZATION_ROLE_TYPE', None),
                     has_global_access=getattr(settings, 'AUTH_LDAP_SENTRY_ORGANIZATION_GLOBAL_ACCESS', False),
                     flags=getattr(OrganizationMember.flags, 'sso:linked'),
                 )
+            sentry_teams_from_ldap_group = _get_effective_sentry_teams(ldap_user)
+            for team_slug in sentry_teams_from_ldap_group:
+                try:
+                    team = Team.objects.get(organization=organization, slug=team_slug)
+                    OrganizationMemberTeam.objects.create_or_update(team=team, organizationmember=organization_member)
+                except Team.DoesNotExist:
+                    pass
 
         # Set subscribe_by_default for new user
         if built and not getattr(settings, 'AUTH_LDAP_SENTRY_SUBSCRIBE_BY_DEFAULT', True):

--- a/sentry_auth_ldap/backend.py
+++ b/sentry_auth_ldap/backend.py
@@ -24,6 +24,9 @@ elif compare_versions(sentry_version, "24.8.0"):
 else:
     from sentry.models import UserEmail
 
+import logging
+logger = logging.getLogger('django_auth_ldap')
+
 def _get_effective_sentry_role(ldap_user):
     role_priority_order = [
         'member',
@@ -124,8 +127,9 @@ class SentryLdapBackend(LDAPBackend):
             for team_slug in sentry_teams_from_ldap_group:
                 try:
                     team = Team.objects.get(organization=organization, slug=team_slug)
-                    OrganizationMemberTeam.objects.create_or_update(team=team, organizationmember=organization_member)
+                    OrganizationMemberTeam.objects.get_or_create(team=team, organizationmember=organization_member)
                 except Team.DoesNotExist:
+                    logger.warning(f'Team {team_slug} does not exist')
                     pass
 
         # Set subscribe_by_default for new user


### PR DESCRIPTION
Fixes #26 

Adds a dictionary which can be used to map LDAP groups to one or multiple teams which the user will become a member of.